### PR TITLE
fix: fix broken start script, document how to preview a production build

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Create a production build:
 npm run build
 ```
 
+## Previewing a Production build
+
+To preview a production build locally, use the [Netlify CLI](https://cli.netlify.com):
+
+```bash
+npx netlify-cli serve
+```
+
+```bash
+npm run build
+```
+
 ## Deployment
 
 This template is configured for deployment to Netlify.

--- a/README.md
+++ b/README.md
@@ -56,14 +56,18 @@ npm run build
 
 ## Deployment
 
-This template is configured for deployment to Netlify.
+This template is preconfigured for deployment to Netlify.
 
-See <https://docs.netlify.com/welcome/add-new-site/> to add this project as a site
+Follow <https://docs.netlify.com/welcome/add-new-site/> to add this project as a site
 in your Netlify account.
 
 ## Styling
 
 This template comes with [Tailwind CSS](https://tailwindcss.com/) already configured for a simple default starting experience. You can use whatever CSS framework you prefer.
+
+## See also
+
+[Guide: how to deploy a React Router 7 site to Netlify](https://developers.netlify.com/guides/how-to-deploy-a-react-router-7-site-to-netlify/)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "react-router build",
     "dev": "react-router dev",
-    "start": "react-router-serve ./build/server/index.js",
+    "start": "npm run dev",
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {


### PR DESCRIPTION
The `npm run start` script was left over from the upstream base RR7 template. It does not work with the Netlify setup in this template. This changes it to an alias of `npm run dev`.

I also added a README section documenting a good way to preview a production build.

Fixes https://github.com/netlify/remix-compute/issues/494.