### PR TITLE
fix: node modules resolutions for missing mjs files

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,10 @@ publish = "build/client"
 
 [dev]
 command = "react-router dev"
+
+[functions]
+included_files = [
+    "node_modules/@react-router/**/dist/**",
+    "node_modules/react-router/dist/**",
+    "node_modules/turbo-stream/dist/**"
+  ]


### PR DESCRIPTION
Node 20.19 and node 22.x introduce more strict behavior in resolving node modules. This causes the error in the local netlify-cli serve and when deployed. This fix allows this example to work with node 20|22.


> Error - Cannot find module '/../react-router-template/.netlify/functions-serve/.unzipped/react-router-server/node_modules/@react-router/node/dist/index.mjs' imported from /../react-router-template/.netlify/functions-serve/.unzipped/react-router-server/.netlify/v1/functions/react-router-server.mjs


Here is a quick vid showing the issue and resolution.

https://github.com/user-attachments/assets/f3c1edcc-0177-4a69-9c82-ab58b082ff13

